### PR TITLE
Integrate exiftool

### DIFF
--- a/integration.yml
+++ b/integration.yml
@@ -7,10 +7,12 @@ milestone: V23-Beta2
 repos: 
   # Required
   - repo: deepin-community/libcompress-raw-lzma-perl
-    tag: 2.204-1
+    tagsha: 'dadd278132b5864e1f5083c41faf0faa7cb5aee6'
+    # tag: 2.204-1
     order: 0
   - repo: deepin-community/libio-compress-brotli-perl
-    tag: 0.004001-2deepin
+    tagsha: '042167d59478f09bc0b8c4a8cec42b61f7f8673c'
+    # tag: 0.004001-2deepin
     order: 0
   - repo: deepin-community/libimage-exiftool-perl
     tag: 12.63+dfsg-2

--- a/integration.yml
+++ b/integration.yml
@@ -1,17 +1,17 @@
 # Required
 message: |
-  Integrated for V23-Beta2
+  Integrate exiftool for V23-Beta2
 # Not required, now default is V23-Beta2
 milestone: V23-Beta2
 # Required
 repos: 
   # Required
-  - repo: linuxdeepin/examplerepo
-    # Not required
-    tag: 5.11.22
-    # Not required
+  - repo: deepin-community/libcompress-raw-lzma-perl
+    tag: 2.204-1
     order: 0
-    # Not required, but need one of tag and tagsha info
-    # When use tag info, integration workflow will check repository tag and build tag version
-    # When use tagsha info, interation workflow will build tagsha version, It doesn't matter whether the tag exists.
-    tagsha: "********************************"
+  - repo: deepin-community/libio-compress-brotli-perl
+    tag: 0.004001-2deepin
+    order: 0
+  - repo: deepin-community/libimage-exiftool-perl
+    tag: 12.63+dfsg-2
+    order: 1


### PR DESCRIPTION
CVE-2022-23935

<!--
exiftool CVE-2022-23935 测试意见

1. 确认当前 exiftool（包名：libimage-exiftool-perl）版本 >= 12.38
2. 确保目录下无名为 pwn 的文件
3. 创建 文件名为 touch pwn | 的空文件
4. 运行 exiftool 'touch pwn |'
5. 检查目录下是否存在 pwn 文件。如存在 pwn 文件，说明 exiftool 会受到攻击；如不存在 pwn 文件，说明没问题。

参考命令：

```sh
$ apt list libimage-exiftool-perl
$ ls pwn
ls: cannot access 'pwn': No such file or directory
$ touch 'touch pwn |'
$ ./exiftool 'touch pwn |'
ExifTool Version Number         : 12.37
File Name                       : touch pwn |
Directory                       : .
File Size                       : 0 bytes
File Modification Date/Time     : 2022:01:18 18:40:18-06:00
File Access Date/Time           : 2022:01:18 18:40:18-06:00
File Inode Change Date/Time     : 2022:01:18 18:40:18-06:00
File Permissions                : prw-------
Error                           : File is empty
$ ls pwn
pwn
```
-->