### PR TITLE
chore: delete ppx-tools-versioned

### DIFF
--- a/integration.yml
+++ b/integration.yml
@@ -1,17 +1,7 @@
-# Required
 message: |
   Integrated for V23-Beta2
-# Not required, now default is V23-Beta2
 milestone: V23-Beta2
-# Required
 repos: 
-  # Required
-  - repo: linuxdeepin/examplerepo
-    # Not required
-    tag: 5.11.22
-    # Not required
+  - repo: deepin-community/libayatana-appindicator
+    tagsha: "3fe7b10129855062ba96cdee6547f7234408a35e"
     order: 0
-    # Not required, but need one of tag and tagsha info
-    # When use tag info, integration workflow will check repository tag and build tag version
-    # When use tagsha info, interation workflow will build tagsha version, It doesn't matter whether the tag exists.
-    tagsha: "********************************"


### PR DESCRIPTION
ppx-tools-versioned is an old library that do no longer compile with. current OCaml version
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1006355
    
Log: delete package