### PR TITLE
Bulk integration for rebuilding python3 packages

### DIFF
--- a/integration.yml
+++ b/integration.yml
@@ -62,3 +62,83 @@ repos:
     tag: 
     order: 0
     tagsha: "c515278d72d798e340f3e2999c313d95e794b334" 
+
+  - repo: deepin-community/mypy
+    tag: 
+    order: 0
+    tagsha: "811405ec34c290d85450eac17cabfcbb4d5b3831" 
+
+  - repo: deepin-community/python-nacl
+    tag: 
+    order: 0
+    tagsha: "8ee7d886b1ddd3ba9cd72db75cb1380dfe61f5fd" 
+
+  - repo: deepin-community/netifaces
+    tag: 
+    order: 0
+    tagsha: "cf17da202868e891b18d700f11ec22a0e1e94bb5" 
+
+  - repo: deepin-community/nlopt
+    tag: 
+    order: 0
+    tagsha: "05c3e9b13c9bdbfe97237ff022e62f6a12591eca" 
+
+  - repo: deepin-community/numcodecs
+    tag: 
+    order: 0
+    tagsha: "551d9926acc8ca40a74f91590bde701f3c04082b"     
+
+  - repo: deepin-community/libplist
+    tag: 
+    order: 0
+    tagsha: "deb3187ba90e43491193ef6f4de190e540e27d4a" 
+
+  - repo: deepin-community/python-pylibacl
+    tag: 
+    order: 0
+    tagsha: "b2942673fc482a75a3cb334f1eae761bdab7f1a2" 
+
+  - repo: deepin-community/rrdtool
+    tag: 
+    order: 0
+    tagsha: "381f2eae35f8b0cc2ee1e048d1cc2910c509a660" 
+
+  - repo: deepin-community/python-scrypt
+    tag: 
+    order: 0
+    tagsha: "00dc159cfd80a1462e16242ddb70a7c4dac6c67c" 
+
+  - repo: deepin-community/skimage
+    tag: 
+    order: 0
+    tagsha: "8f221778bd6bfd1fa0dbab81dbfc622a8af942fa" 
+
+  - repo: deepin-community/scikit-learn
+    tag: 
+    order: 0
+    tagsha: "531c62ef6f7c6448125cbc402c10199e78103753" 
+
+  - repo: deepin-community/i2c-tools
+    tag: 
+    order: 0
+    tagsha: "2f60c5649458ac0efa135cda21a0a995b1a3ec18" 
+
+  - repo: deepin-community/i2c-tools
+    tag: 
+    order: 0
+    tagsha: "2f60c5649458ac0efa135cda21a0a995b1a3ec18" 
+
+  - repo: deepin-community/python-systemd
+    tag: 
+    order: 0
+    tagsha: "9cda18d7fd080d18acc7f4b5f3dc1b0eb318a296" 
+
+  - repo: deepin-community/vtk9
+    tag: 
+    order: 0
+    tagsha: "891e3f7b014f42eeda01b125ad6511301fa6ac23" 
+
+  - repo: deepin-community/zbar
+    tag: 
+    order: 0
+    tagsha: "8e84e2232642ff0973270b0ee9d20e03c8539ab6" 

--- a/integration.yml
+++ b/integration.yml
@@ -76,11 +76,15 @@ repos:
   - repo: deepin-community/netifaces
     tag: 
     order: 0
-    tagsha: "cf17da202868e891b18d700f11ec22a0e1e94bb5" 
+    tagsha: "cf17da202868e891b18d700f11ec22a0e1e94bb5"
+
+  - repo: deepin-community/dh-octave
+    tagsha: "724f0cc631eaf4b427f7c58e620361a08a001f3d"
+    order: 0
 
   - repo: deepin-community/nlopt
     tag: 
-    order: 0
+    order: 1
     tagsha: "05c3e9b13c9bdbfe97237ff022e62f6a12591eca" 
 
   - repo: deepin-community/numcodecs

--- a/integration.yml
+++ b/integration.yml
@@ -41,7 +41,7 @@ repos:
   - repo: deepin-community/ecmwflibs
     tag: 
     order: 0
-    tagsha: "9e014d1dd2ab78b510ac60ad2def065c94808e53"  
+    tagsha: "13bfc7630652fe4317417353bfe673070084bdce"  
 
   - repo: deepin-community/hamlib
     tag: 

--- a/integration.yml
+++ b/integration.yml
@@ -11,7 +11,7 @@ repos:
   - repo: deepin-community/python-aiohttp
     tag: 
     order: 0
-    tagsha: "987fc242cd4eef634ea54cded38f4b8b8dbd77c5"   
+    tagsha: "59665c487d924546289de156395e90e3a5a6cdee"
     
   - repo: deepin-community/audit
     tag: 1%3.0.9-1
@@ -26,7 +26,7 @@ repos:
   - repo: deepin-community/btrfs-progs
     tag: 
     order: 0
-    tagsha: "07fe49a26067c99b447d580fd307591c778ba683"  
+    tagsha: "4f9854c69a1c8a44c3c53c0d7ca84e027fa8d9a3"
 
   - repo: deepin-community/python-cbor
     tag: 
@@ -56,7 +56,7 @@ repos:
   - repo: deepin-community/ldns
     tag: 
     order: 0
-    tagsha: "3683b085a3dd84228a2db7d5116b1ad16c227e1d" 
+    tagsha: "19ea19c234598e77d379ecb830940c9498247c4b"
 
   - repo: deepin-community/marisa
     tag: 

--- a/integration.yml
+++ b/integration.yml
@@ -63,16 +63,6 @@ repos:
     order: 0
     tagsha: "c515278d72d798e340f3e2999c313d95e794b334" 
 
-  - repo: deepin-community/mypy
-    tag: 
-    order: 0
-    tagsha: "811405ec34c290d85450eac17cabfcbb4d5b3831" 
-
-  - repo: deepin-community/python-nacl
-    tag: 
-    order: 0
-    tagsha: "8ee7d886b1ddd3ba9cd72db75cb1380dfe61f5fd" 
-
   - repo: deepin-community/netifaces
     tag: 
     order: 0

--- a/integration.yml
+++ b/integration.yml
@@ -112,16 +112,6 @@ repos:
     order: 0
     tagsha: "00dc159cfd80a1462e16242ddb70a7c4dac6c67c" 
 
-  - repo: deepin-community/skimage
-    tag: 
-    order: 0
-    tagsha: "8f221778bd6bfd1fa0dbab81dbfc622a8af942fa" 
-
-  - repo: deepin-community/scikit-learn
-    tag: 
-    order: 0
-    tagsha: "531c62ef6f7c6448125cbc402c10199e78103753" 
-
   - repo: deepin-community/i2c-tools
     tag: 
     order: 0

--- a/integration.yml
+++ b/integration.yml
@@ -1,17 +1,64 @@
 # Required
 message: |
-  Integrated for V23-Beta2
-# Not required, now default is V23-Beta2
+  Integrated python rebuild
 milestone: V23-Beta2
-# Required
 repos: 
-  # Required
-  - repo: linuxdeepin/examplerepo
-    # Not required
-    tag: 5.11.22
-    # Not required
+  - repo: deepin-community/hplip
+    tag: 3.22.10+dfsg0-2
     order: 0
-    # Not required, but need one of tag and tagsha info
-    # When use tag info, integration workflow will check repository tag and build tag version
-    # When use tagsha info, interation workflow will build tagsha version, It doesn't matter whether the tag exists.
-    tagsha: "********************************"
+    tagsha: 
+    
+  - repo: deepin-community/python-aiohttp
+    tag: 
+    order: 0
+    tagsha: "987fc242cd4eef634ea54cded38f4b8b8dbd77c5"   
+    
+  - repo: deepin-community/audit
+    tag: 1%3.0.9-1
+    order: 0
+    tagsha:  
+
+  - repo: deepin-community/avogadrolibs
+    tag: 
+    order: 0
+    tagsha: "fdfd003ffbb7a0769136f41416969d6a6dbef13e"  
+
+  - repo: deepin-community/btrfs-progs
+    tag: 
+    order: 0
+    tagsha: "07fe49a26067c99b447d580fd307591c778ba683"  
+
+  - repo: deepin-community/python-cbor
+    tag: 
+    order: 0
+    tagsha: "38901707122d3723a357cd553ff0f0bbc701b083"  
+
+  - repo: deepin-community/python-cups
+    tag: 
+    order: 0
+    tagsha: "1fcdb252dced7f289124d99b3919998b2a5ab1ef"  
+
+  - repo: deepin-community/ecmwflibs
+    tag: 
+    order: 0
+    tagsha: "9e014d1dd2ab78b510ac60ad2def065c94808e53"  
+
+  - repo: deepin-community/hamlib
+    tag: 
+    order: 0
+    tagsha: "56cc37a97881952b4effd32691249c52f0004eed"  
+
+  - repo: deepin-community/libimobiledevice
+    tag: 
+    order: 0
+    tagsha: "0f83685c928cdac796083a9f1b731edb5b4adfe9" 
+
+  - repo: deepin-community/ldns
+    tag: 
+    order: 0
+    tagsha: "3683b085a3dd84228a2db7d5116b1ad16c227e1d" 
+
+  - repo: deepin-community/marisa
+    tag: 
+    order: 0
+    tagsha: "c515278d72d798e340f3e2999c313d95e794b334" 

--- a/integration.yml
+++ b/integration.yml
@@ -105,7 +105,7 @@ repos:
   - repo: deepin-community/rrdtool
     tag: 
     order: 0
-    tagsha: "381f2eae35f8b0cc2ee1e048d1cc2910c509a660" 
+    tagsha: "c936c96904304eff2eef67ea29d53bb35676d28e" 
 
   - repo: deepin-community/python-scrypt
     tag: 


### PR DESCRIPTION
successor of #232.



mypy 构建失败: glibc 版本有误

<details>

<summary>python-nacl 构建失败</summary>

```
[  195s] dh_python3
[  195s] D: dh_python3 dh_python3:179: version: 5.20230130+rb2
[  195s] D: dh_python3 dh_python3:180: argv: ['/usr/bin/dh_python3']
[  195s] D: dh_python3 dh_python3:181: options: Namespace(guess_deps=True, skip_private=False, verbose=True, arch=None, package=None, no_package=None, remaining_packages=False, compile_all=False, vrange=None, regexpr=None, accept_upstream_versions=False, depends=None, depends_section=None, recommends=None, recommends_section=None, suggests=None, suggests_section=None, requires=None, shebang=None, ignore_shebangs=False, clean_dbg_pkg=True, no_ext_rename=False, no_shebang_rewrite=False, private_dir=None, O=None)
[  195s] D: dh_python3 dh_python3:182: supported Python versions: 3.9,3.10 (default=3.10)
[  195s] D: dh_python3 debhelper:149: skipping package: python-nacl-doc
[  195s] D: dh_python3 debhelper:183: source=python-nacl, binary packages=['python3-nacl']
[  195s] D: dh_python3 dh_python3:204: processing package python3-nacl...
[  195s] D: dh_python3 fs:52: moving files from debian/python3-nacl/usr/lib/python3.9/dist-packages to debian/python3-nacl/usr/lib/python3/dist-packages/
[  195s] D: dh_python3 fs:52: moving files from debian/python3-nacl/usr/lib/python3.10/dist-packages to debian/python3-nacl/usr/lib/python3/dist-packages/
[  195s] W: dh_python3 fs:147: Paths differ: debian/python3-nacl/usr/lib/python3.10/dist-packages/.hypothesis/unicode_data/13.0.0/charmap.json.gz and debian/python3-nacl/usr/lib/python3/dist-packages/.hypothesis/unicode_data/13.0.0/charmap.json.gz
[  195s] Traceback (most recent call last):
[  195s]   File "/usr/bin/dh_python3", line 292, in <module>
[  195s]     main()
[  195s]   File "/usr/bin/dh_python3", line 218, in main
[  195s]     fix_locations(package, interpreter, SUPPORTED, options)
[  195s]   File "/usr/share/dh-python/dhpython/fs.py", line 53, in fix_locations
[  195s]     share_files(srcdir, dstdir, interpreter, options)
[  195s]   File "/usr/share/dh-python/dhpython/fs.py", line 128, in share_files
[  195s]     share_files(fpath1, fpath2, interpreter, options)
[  195s]   File "/usr/share/dh-python/dhpython/fs.py", line 128, in share_files
[  195s]     share_files(fpath1, fpath2, interpreter, options)
[  195s]   File "/usr/share/dh-python/dhpython/fs.py", line 128, in share_files
[  195s]     share_files(fpath1, fpath2, interpreter, options)
[  195s]   File "/usr/share/dh-python/dhpython/fs.py", line 150, in share_files
[  195s]     fromlines = fp1.readlines()
[  195s]   File "/usr/lib/python3.10/codecs.py", line 322, in decode
[  195s]     (result, consumed) = self._buffer_decode(data, self.errors, final)
[  195s] UnicodeDecodeError: 'utf-8' codec can't decode byte 0x8b in position 1: invalid start byte
[  195s] make[1]: *** [debian/rules:44: override_dh_python3] Error 1
[  195s] make[1]: Leaving directory '/usr/src/packages/BUILD'
[  195s] make: *** [debian/rules:21: binary] Error 2
[  195s] dpkg-buildpackage: error: fakeroot debian/rules binary subprocess returned exit status 2
```

</details>


rrdtool dh_missing 错误: https://github.com/deepin-community/rrdtool/pull/2

~scikit-learn 与 skimage 循环依赖 （??可能??需要使用 build profile）~（已排除在集成外）
