### PR TITLE
fix: rebuild spdlog

### DIFF
--- a/integration.yml
+++ b/integration.yml
@@ -5,13 +5,10 @@ message: |
 milestone: V23-Beta2
 # Required
 repos: 
-  # Required
-  - repo: linuxdeepin/examplerepo
-    # Not required
-    tag: 5.11.22
-    # Not required
+  # - repo: linuxdeepin/dtkcore
+  #   tag: 5.6.16
+  #   order: 1
+  - repo: deepin-community/spdlog
+    # tag: 1:1.10.0+ds-0.4
+    tagsha: 431a20e6a6fb35c784bf67723024a97570774730
     order: 0
-    # Not required, but need one of tag and tagsha info
-    # When use tag info, integration workflow will check repository tag and build tag version
-    # When use tagsha info, interation workflow will build tagsha version, It doesn't matter whether the tag exists.
-    tagsha: "********************************"


### PR DESCRIPTION
本次集成**重新**集成了 spdlog 与 dtkcore。

由于之前的构建环境中没有 Preinstall: apt，Provides 字段本应为 `libspdlog1.10-fmt9`，
而因为 spdlog 的 d/rules 中与 apt 相关的命令失效，产生了 Provides: `libspdlog1.10-fmt` 的包。

本次集成应关注：
1. 构建过程中 apt 是否被安装
2. spdlog 构建产物的 Provides 字段
3. rebuild 标签

