### PR TITLE
integrate nvidia-graphics-drivers for kernel 6.6

### DIFF
--- a/integration.yml
+++ b/integration.yml
@@ -1,15 +1,10 @@
 # Required
 message: |
-  Integrated for V23-Beta3
+  Integrate nvidia-graphics-drivers for V23-Beta3
 # Not required, now default is V23-Beta3
 milestone: V23-Beta3
 # Required
 repos: 
   # Required
-  - repo: linuxdeepin/examplerepo
-    # Not required
-    tag: 5.11.22
-    # Not required, but need one of tag and tagsha info
-    # When use tag info, integration workflow will check repository tag and build tag version
-    # When use tagsha info, interation workflow will build tagsha version, It doesn't matter whether the tag exists.
-    tagsha: "********************************"
+  - repo: deepin-community/nvidia-graphics-drivers
+    tagsha: "3387452df30f6bd3ce0e1aaf72a4987d1c623228"


### PR DESCRIPTION
nvidia-graphics-drivers 不在 github 维护，直接 OBS 集成。见 [#6335](https://github.com/linuxdeepin/developer-center/issues/6335)