### PR TITLE
chore(CI): github integrate workflow add i386\loong64\riscv64 arch support

### DIFF
--- a/.github/workflows/02-build-obs.yml
+++ b/.github/workflows/02-build-obs.yml
@@ -168,7 +168,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        arch: [aarch64, x86_64]
+        arch: [aarch64, x86_64, i386, loong64, riscv64]
 
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/obs-proj-component-meta.tpl
+++ b/.github/workflows/obs-proj-component-meta.tpl
@@ -10,5 +10,8 @@
     <path project="deepin:CI:TestingIntegration:TOPIC" repository="testing"/>
     <arch>aarch64</arch>
     <arch>x86_64</arch>
+    <arch>i386</arch>
+    <arch>loong64</arch>
+    <arch>riscv64</arch>
   </repository>
 </project>

--- a/.github/workflows/obs-proj-meta.tpl
+++ b/.github/workflows/obs-proj-meta.tpl
@@ -9,5 +9,8 @@
     <path project="deepin:CI" repository="deepin_testing"/>
     <arch>aarch64</arch>
     <arch>x86_64</arch>
+    <arch>i386</arch>
+    <arch>loong64</arch>
+    <arch>riscv64</arch>
   </repository>
 </project>


### PR DESCRIPTION
需要ci backend配置更新，同时需要添加ci backend下的构建节点。