### PR TITLE
集成流程调整

### DIFF
--- a/.github/workflows/02-build-obs.yml
+++ b/.github/workflows/02-build-obs.yml
@@ -130,16 +130,23 @@ jobs:
           curl -o meta.xml https://raw.githubusercontent.com/deepin-community/Repository-Integration/master/.github/workflows/obs-pkg-meta.tpl
           sed -i "s#PKGNAME#${pkgname}#g" meta.xml
           targeturl="https://build.deepin.com/project/show/deepin:CI:TestingIntegration:${TOPIC}"
+          uploadurl="https://build.deepin.com/source/deepin:CI:TestingIntegration:${TOPIC}"
           if [ "$COMPONENT" = "main" ]; then
             sed -i "s#Testing:COMPONENT#CI:TestingIntegration:${TOPIC}#g" meta.xml
             curl -X PUT -u golf66:$OSCPASS -H "Content-type: text/xml" -d @meta.xml "https://build.deepin.com/source/deepin:CI:TestingIntegration:${TOPIC}/$pkgname/_meta"
-            osc co deepin:CI:TestingIntegration:${TOPIC}/${pkgname} && cd $_
+            # osc co deepin:CI:TestingIntegration:${TOPIC}/${pkgname} && cd $_
+            osc co deepin:CI:TestingIntegration:${TOPIC}/${pkgname} _branch_request || true
+            osc co deepin:CI:TestingIntegration:${TOPIC}/${pkgname} _service || true
             targeturl="https://build.deepin.com/package/live_build_log/deepin:CI:TestingIntegration:${TOPIC}/$pkgname/testing/"
+            uploadurl="https://build.deepin.com/source/deepin:CI:TestingIntegration:${TOPIC}/$pkgname"
           else
             sed -i "s#Testing:COMPONENT#CI:TestingIntegration:${TOPIC}:${COMPONENT}#g" meta.xml
             curl -X PUT -u golf66:$OSCPASS -H "Content-type: text/xml" -d @meta.xml "https://build.deepin.com/source/deepin:CI:TestingIntegration:${TOPIC}:${COMPONENT}/$pkgname/_meta"
-            osc co deepin:CI:TestingIntegration:${TOPIC}:${COMPONENT}/${pkgname} && cd $_
+            # osc co deepin:CI:TestingIntegration:${TOPIC}:${COMPONENT}/${pkgname} && cd $_
+            osc co deepin:CI:TestingIntegration:${TOPIC}:${COMPONENT}/${pkgname} _branch_request || true
+            osc co deepin:CI:TestingIntegration:${TOPIC}:${COMPONENT}/${pkgname} _service || true
             targeturl="https://build.deepin.com/package/live_build_log/deepin:CI:TestingIntegration:${TOPIC}:${COMPONENT}/$pkgname/testing/"
+            uploadurl="https://build.deepin.com/source/deepin:CI:TestingIntegration:${TOPIC}:${COMPONENT}/$pkgname"
           fi
           echo "targeturl=$targeturl" >> $GITHUB_OUTPUT
 
@@ -149,13 +156,15 @@ jobs:
           fi
           if [ ! -f _service ];then
             curl -o _service https://raw.githubusercontent.com/deepin-community/Repository-Integration/master/.github/workflows/obs-pkg.tpl && \
-            sed -i "s#REPO#$REPO#g" _service && osc add _service && osc ci -m "init"
+            sed -i "s#REPO#$REPO#g" _service
+            curl -X PUT -u golf66:$OSCPASS -d @_service -s "$uploadurl/_service"
           fi
           if [ $needbuild = "true" ];then
             curl -o _branch_request https://raw.githubusercontent.com/deepin-community/Repository-Integration/master/.github/workflows/obs-br.tpl
             sed -i  "s#REPO#$REPO#g" _branch_request
             sed -i "s#TAGSHA#$TAGSHA#g" _branch_request
-            osc add _branch_request && osc ci -m "Update tag release: $TAGSHA"
+            # osc add _branch_request && osc ci -m "Update tag release: $TAGSHA"
+            curl -X PUT -u golf66:$OSCPASS -d @_branch_request -s "$uploadurl/_branch_request"
           else
             echo "$REPO source unchanged, skip!!!"
           fi
@@ -173,7 +182,7 @@ jobs:
       ARCH: ${{ matrix.arch }}
     steps:
       - name: Set commit status as pending
-        if: ${{ needs.build.outputs.needbuild }} == "true"
+        if: ${{ needs.build.outputs.needbuild == 'true' }}
         uses: myrotvorets/set-commit-status-action@master
         with:
           token: ${{ github.token }}
@@ -181,65 +190,3 @@ jobs:
           context: "${{ needs.build.outputs.pkgname }}_${{ matrix.arch }}_testing_repository_building"
           targetUrl: "${{ needs.build.outputs.targeturl }}${{ matrix.arch }}"
           sha: ${{ github.event.pull_request.head.sha }}
-
-      - name: Wait for build to succeed
-        uses: cloudposse/github-action-wait-commit-status@main
-        id: wait-for-build
-        with:
-          repository: ${{ github.repository }}
-          sha: ${{ github.event.pull_request.head.sha }}
-          status: "${{ needs.build.outputs.pkgname }}_${{ matrix.arch }}_testing_repository_building"
-          expected_state: "success"
-          token: ${{ github.token }}
-          check-retry-interval: 60
-          check-retry-count: 60
-
-      - name: Do something with a build time out
-        if: steps.wait-for-build.outputs.conclusion == 'timed_out'
-        id: wait_time_out
-        run: |
-          set -x
-          sudo apt-get update && sudo apt install -y osc
-          mkdir -p ~/.config/osc
-          echo "${{ secrets.OSCRC }}" > ~/.config/osc/oscrc
-          pkgname="${{ needs.build.outputs.pkgname }}"
-          if [ "$COMPONENT" = "main" ]; then
-            osc co deepin:CI:TestingIntegration:${TOPIC}/${pkgname} && cd $_
-          else
-            osc co deepin:CI:TestingIntegration:${TOPIC}:${COMPONENT}/${pkgname} && cd $_
-          fi
-
-          timeouturl="${{ needs.build.outputs.targeturl }}${{ matrix.arch }}"
-          description="wait build complete timeout"
-          status="pending"
-          buildresult=$(osc results -a ${ARCH} -r testing |awk '{print $3}')
-          if [ "$buildresult" = "succeeded" ];then
-            status="success"
-            description=""
-          elif [ "$buildresult" = "excluded" ]; then
-            status="success"
-            description="build excluded"
-            timeouturl=""
-          elif [ "$buildresult" = "failed" ]; then
-            status="failure"
-            description=""
-          fi
-          echo "timeouturl=$timeouturl" >> $GITHUB_OUTPUT
-          echo "description=$description" >> $GITHUB_OUTPUT
-          echo "status=$status" >> $GITHUB_OUTPUT
-
-      - name: Update status build status as timeout
-        if: steps.wait-for-build.outputs.conclusion == 'timed_out'
-        uses: myrotvorets/set-commit-status-action@master
-        with:
-          token: ${{ github.token }}
-          status: ${{ steps.wait_time_out.outputs.status }}
-          context: "${{ needs.build.outputs.pkgname }}_${{ matrix.arch }}_testing_repository_building"
-          targetUrl: ${{ steps.wait_time_out.outputs.timeouturl }}
-          sha: ${{ github.event.pull_request.head.sha }}
-          description: ${{ steps.wait_time_out.outputs.description }}
-
-      #- name: report build error at action
-      #  if: steps.wait_time_out.outputs.status != 'success' || steps.wait-for-build.outputs.conclusion == 'failure'
-      #  run: |
-      #    exit -1

--- a/.github/workflows/auto-integration.yml
+++ b/.github/workflows/auto-integration.yml
@@ -84,8 +84,9 @@ jobs:
             core.setOutput('issueid', issueid)
             core.setOutput('projectItemID', projectItemID)
 
-  create_issue_link_project:
-    name: create issue and link project
+  wait_build_pending_status:
+    name: wait build pending status
+    runs-on: ubuntu-latest
     needs:
       - parsec_integration
       - ouput_message
@@ -99,6 +100,72 @@ jobs:
       (needs.build_main.result == 'success' || needs.build_main.result == 'skipped') &&
       (needs.build_dde.result == 'success' || needs.build_dde.result == 'skipped') &&
       (needs.build_community.result == 'success' || needs.build_community.result == 'skipped')
+    steps:
+      - name: wait build pending status
+        uses: actions/github-script@v6
+        with:
+          script: |
+            let retryCount = 30;
+            let attemptCount = 0;
+
+            function sleep(time){
+              return new Promise((resolve) => setTimeout(resolve, time));
+            }
+
+            if ( context.issue.number != undefined ) {
+              while (true) {
+                const { data: statuses } = await github.rest.repos.getCombinedStatusForRef({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  ref: "${{ github.event.pull_request.head.sha }}",
+                })
+
+                console.log("ref statuses:", statuses)
+                buildStatuses = [];
+                buildStatuses = statuses.statuses.filter((status) => status.context.includes("testing_repository_building"));
+                console.log("ref build statuses:", buildStatuses)
+                const successStatuses = buildStatuses.filter((status) => status.state === "success");
+                console.log("ref success statuses:", successStatuses)
+
+                if (buildStatuses.length == 0) {
+                  core.setFailed(`Can't find obs build statuses, Exiting...`);
+                  break;
+                }
+
+                if (successStatuses.length == buildStatuses.length) {
+                  console.log(`All build commit statuses is now a success.`);
+                  break;
+                }
+
+                if (attemptCount >= retryCount) {
+                  core.setFailed(`Exceeded maximum retry count. Exiting...`);
+                  break;
+                }
+
+                attemptCount++;
+
+                console.log(`Waiting for commit statuses to become a success...`);
+                await sleep(60000)
+              }
+            }
+
+  create_issue_link_project:
+    name: create issue and link project
+    needs:
+      - parsec_integration
+      - ouput_message
+      - build_project_prepare
+      - build_main
+      - build_dde
+      - build_community
+      - wait_build_pending_status
+    if: |
+      always() && !cancelled() &&
+      (needs.parsec_integration.result == 'success') && (needs.ouput_message.result != 'failure' ) &&
+      (needs.build_main.result == 'success' || needs.build_main.result == 'skipped') &&
+      (needs.build_dde.result == 'success' || needs.build_dde.result == 'skipped') &&
+      (needs.build_community.result == 'success' || needs.build_community.result == 'skipped') &&
+      needs.wait_build_pending_status != 'failure'
     uses: deepin-community/Repository-Integration/.github/workflows/issue-project-manager.yml@master
     secrets: inherit
     with:


### PR DESCRIPTION
1. 取消obs构建流程等待每个包的构建状态，当等待流程转移到auto-integrateion流程中，一次行做所有包的构建流程等待，减少github action runner的占用数量
2. 优化osc下载，只下载必要的_branch_request_和_service文件，提升obs集成构建准备时间

备注：目前在auto-integrateion流程中通过轮询检查以testing_repository_building结尾的obs github commit statuses，当所有的obs构建状态都success后等待结束，等待超时30分钟。